### PR TITLE
- Build version is not posted to log viewer whenever the pom.xml file…

### DIFF
--- a/src/main/java/com/vodichian/packager/ProjectToolsController.java
+++ b/src/main/java/com/vodichian/packager/ProjectToolsController.java
@@ -81,7 +81,9 @@ public class ProjectToolsController {
                     project.add(new Launch4jTool(new ToolSettings().setName(toolName), new LaunchExecutor()));
                     break;
                 case BUILD_EXTRACTOR:
-                    project.add(new BuildTool(new BuildToolSettings().setName(toolName), new BuildExecutor()));
+                    BuildToolSettings toolSettings = new BuildToolSettings();
+                    toolSettings.setName(toolName);
+                    project.add(new BuildTool(toolSettings, new BuildExecutor()));
                     break;
             }
             update();

--- a/src/main/java/com/vodichian/packager/projects/ProjectManager.java
+++ b/src/main/java/com/vodichian/packager/projects/ProjectManager.java
@@ -149,7 +149,7 @@ public class ProjectManager {
             case BUILD_EXTRACTOR: {
                 ToolSettings settings = buildSettings(toolYaml, new BuildToolSettings());
                 settings.setName(toolName);
-                tool = new BuildTool(settings, new BuildExecutor());
+                tool = new BuildTool((BuildToolSettings) settings, new BuildExecutor());
                 break;
             }
             default: {

--- a/src/main/java/com/vodichian/packager/tool/AbstractTool.java
+++ b/src/main/java/com/vodichian/packager/tool/AbstractTool.java
@@ -92,4 +92,8 @@ public abstract class AbstractTool {
         return settings;
     }
 
+    public Executor getExecutor() {
+        return executor;
+    }
+
 }

--- a/src/main/java/com/vodichian/packager/tool/BuildExecutor.java
+++ b/src/main/java/com/vodichian/packager/tool/BuildExecutor.java
@@ -245,11 +245,11 @@ public class BuildExecutor implements Executor {
     /**
      * Extract the version information from the pom.xml file provided in {@link ToolSettings#getConfiguration()}
      *
-     * @param buildSettings the {@link ToolSettings} to extact the version info from
+     * @param buildSettings the {@link ToolSettings} to extract the version info from
      * @return the extracted version information
      * @throws PackagerException if file can't be opened or an XML error occurs during parse
      */
-    private String getVersion(ToolSettings buildSettings) throws PackagerException {
+    public String getVersion(ToolSettings buildSettings) throws PackagerException {
         MavenXpp3Reader reader = new MavenXpp3Reader();
         try {
             Model model = reader.read(new FileReader(buildSettings.getConfiguration()));

--- a/src/main/java/com/vodichian/packager/tool/BuildTool.java
+++ b/src/main/java/com/vodichian/packager/tool/BuildTool.java
@@ -1,11 +1,25 @@
 package com.vodichian.packager.tool;
 
+import com.vodichian.packager.PackagerException;
+import javafx.beans.Observable;
+
 import java.io.File;
 import java.nio.file.Files;
 
 public class BuildTool extends AbstractTool {
-    public BuildTool(ToolSettings settings, Executor executor) {
+    public BuildTool(BuildToolSettings settings, Executor executor) {
         super(settings, executor);
+        settings.configurationProperty.addListener(this::postVersion);
+    }
+
+    private void postVersion(Observable observable) {
+        try {
+            String version = ((BuildExecutor) getExecutor()).getVersion(getSettings());
+            post("Project version found: " + version);
+        } catch (PackagerException e) {
+            post("Failed to extract version: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
… is set in a BuildTool

- This closes issue - Display extracted build number to UI before run #34